### PR TITLE
Add challenge detail pages and simplify account login

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -49,6 +49,7 @@ const App = () => {
                 <Route path="/" element={<Index />} />
                 <Route path="/challenges" element={<Challenges />} />
                 <Route path="/challenges/:slug" element={<ChallengeDetail />} />
+                <Route path="/challenges/:slug/:sub" element={<ChallengeSubPage />} />
                 <Route path="/account" element={<Account />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -12,6 +12,7 @@ import NotFound from "./pages/NotFound";
 import { Header } from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import Challenges from "@/pages/Challenges";
+import ChallengeDetail from "@/pages/ChallengeDetail";
 import Account from "@/pages/Account";
 
 const queryClient = new QueryClient();

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -13,6 +13,7 @@ import { Header } from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import Challenges from "@/pages/Challenges";
 import ChallengeDetail from "@/pages/ChallengeDetail";
+import ChallengeSubPage from "@/pages/ChallengeSubPage";
 import Account from "@/pages/Account";
 
 const queryClient = new QueryClient();

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -50,7 +50,10 @@ const App = () => {
                 <Route path="/" element={<Index />} />
                 <Route path="/challenges" element={<Challenges />} />
                 <Route path="/challenges/:slug" element={<ChallengeDetail />} />
-                <Route path="/challenges/:slug/:sub" element={<ChallengeSubPage />} />
+                <Route
+                  path="/challenges/:slug/:sub"
+                  element={<ChallengeSubPage />}
+                />
                 <Route path="/account" element={<Account />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -48,7 +48,7 @@ const App = () => {
               <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/challenges" element={<Challenges />} />
-                <Route path="/challenges/:slug" element={<Challenges.Detail />} />
+                <Route path="/challenges/:slug" element={<ChallengeDetail />} />
                 <Route path="/account" element={<Account />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -47,6 +47,7 @@ const App = () => {
               <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/challenges" element={<Challenges />} />
+                <Route path="/challenges/:slug" element={<Challenges.Detail />} />
                 <Route path="/account" element={<Account />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -14,6 +14,8 @@ import Footer from "@/components/layout/Footer";
 import Challenges from "@/pages/Challenges";
 import ChallengeDetail from "@/pages/ChallengeDetail";
 import ChallengeSubPage from "@/pages/ChallengeSubPage";
+import Impact from "@/pages/Impact";
+import About from "@/pages/About";
 import Account from "@/pages/Account";
 
 const queryClient = new QueryClient();

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -56,6 +56,8 @@ const App = () => {
                   path="/challenges/:slug/:sub"
                   element={<ChallengeSubPage />}
                 />
+                <Route path="/impact" element={<Impact />} />
+                <Route path="/about" element={<About />} />
                 <Route path="/account" element={<Account />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -46,14 +46,14 @@ export default function Footer() {
             </p>
             <ul className="space-y-1">
               <li>
-                <a href="#impact" className="hover:underline">
+                <Link to="/impact" className="hover:underline">
                   Impact
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#stakeholders" className="hover:underline">
-                  Stakeholders
-                </a>
+                <Link to="/about" className="hover:underline">
+                  About
+                </Link>
               </li>
               <li>
                 <a href="#faq" className="hover:underline">

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -51,6 +51,24 @@ export function Header() {
             Challenges
           </Link>
           <Link
+            to="/impact"
+            className={cn(
+              "rounded-md px-3 py-2 text-sm font-medium text-foreground/80 hover:bg-accent hover:text-foreground",
+              isActive("/impact") && "bg-accent text-foreground",
+            )}
+          >
+            Impact
+          </Link>
+          <Link
+            to="/about"
+            className={cn(
+              "rounded-md px-3 py-2 text-sm font-medium text-foreground/80 hover:bg-accent hover:text-foreground",
+              isActive("/about") && "bg-accent text-foreground",
+            )}
+          >
+            About
+          </Link>
+          <Link
             to="/account"
             className={cn(
               "rounded-md px-3 py-2 text-sm font-medium text-foreground/80 hover:bg-accent hover:text-foreground",

--- a/client/global.css
+++ b/client/global.css
@@ -106,12 +106,25 @@
   body {
     @apply bg-background text-foreground;
     background-image:
-      radial-gradient(1200px 600px at 10% -10%, hsl(var(--accent)) 8%, transparent 60%),
-      radial-gradient(1200px 600px at 110% -10%, hsl(var(--accent)) 8%, transparent 60%),
+      radial-gradient(
+        1200px 600px at 10% -10%,
+        hsl(var(--accent)) 8%,
+        transparent 60%
+      ),
+      radial-gradient(
+        1200px 600px at 110% -10%,
+        hsl(var(--accent)) 8%,
+        transparent 60%
+      ),
       linear-gradient(transparent 0, transparent 99%),
       linear-gradient(90deg, hsl(var(--border)) 1px, transparent 1px),
       linear-gradient(0deg, hsl(var(--border)) 1px, transparent 1px);
-    background-size: auto, auto, auto, 48px 48px, 48px 48px;
+    background-size:
+      auto,
+      auto,
+      auto,
+      48px 48px,
+      48px 48px;
     background-position: center, center, center, center, center;
     background-repeat: no-repeat, no-repeat, no-repeat, repeat, repeat;
     background-attachment: fixed;

--- a/client/global.css
+++ b/client/global.css
@@ -105,5 +105,15 @@
 
   body {
     @apply bg-background text-foreground;
+    background-image:
+      radial-gradient(1200px 600px at 10% -10%, hsl(var(--accent)) 8%, transparent 60%),
+      radial-gradient(1200px 600px at 110% -10%, hsl(var(--accent)) 8%, transparent 60%),
+      linear-gradient(transparent 0, transparent 99%),
+      linear-gradient(90deg, hsl(var(--border)) 1px, transparent 1px),
+      linear-gradient(0deg, hsl(var(--border)) 1px, transparent 1px);
+    background-size: auto, auto, auto, 48px 48px, 48px 48px;
+    background-position: center, center, center, center, center;
+    background-repeat: no-repeat, no-repeat, no-repeat, repeat, repeat;
+    background-attachment: fixed;
   }
 }

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Leaf, Users, Target, Rocket } from "lucide-react";
+
+export default function About() {
+  return (
+    <section className="relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(60%_60%_at_10%_10%,hsl(var(--accent))_0%,transparent_50%),radial-gradient(60%_60%_at_90%_10%,hsl(var(--accent))_0%,transparent_50%)]" />
+      <div className="container py-10">
+        <div className="mx-auto max-w-4xl text-center">
+          <Badge variant="secondary" className="mb-3">Environment • Hackathon</Badge>
+          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">About EcoSpark</h1>
+          <p className="mt-2 text-muted-foreground">A gamified platform that turns environmental learning into measurable action.</p>
+        </div>
+
+        <div className="mt-8 grid gap-6 sm:grid-cols-2">
+          <Card className="border-primary/20">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><Leaf className="h-5 w-5" /> Mission</CardTitle>
+              <CardDescription>Build lifelong sustainable habits through local action.</CardDescription>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">Aligned with NEP 2020 and India’s SDGs, designed with teachers and NGOs.</CardContent>
+          </Card>
+          <Card className="border-primary/20">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><Users className="h-5 w-5" /> Community</CardTitle>
+              <CardDescription>Students, teachers, NGOs, and departments.</CardDescription>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">Run eco‑clubs, leaderboards, and local drives with simple tools.</CardContent>
+          </Card>
+          <Card className="border-primary/20">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><Target className="h-5 w-5" /> Focus</CardTitle>
+              <CardDescription>Waste, Water, Energy</CardDescription>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">Short modules, micro‑challenges, and impact tracking.</CardContent>
+          </Card>
+          <Card className="border-primary/20">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><Rocket className="h-5 w-5" /> Built for Hackathons</CardTitle>
+              <CardDescription>Clear outcomes and fast demos</CardDescription>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">Beautiful UI, rapid onboarding, and sample data to showcase impact.</CardContent>
+          </Card>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -1,4 +1,10 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Leaf, Users, Target, Rocket } from "lucide-react";
 
@@ -8,39 +14,68 @@ export default function About() {
       <div className="absolute inset-0 -z-10 bg-[radial-gradient(60%_60%_at_10%_10%,hsl(var(--accent))_0%,transparent_50%),radial-gradient(60%_60%_at_90%_10%,hsl(var(--accent))_0%,transparent_50%)]" />
       <div className="container py-10">
         <div className="mx-auto max-w-4xl text-center">
-          <Badge variant="secondary" className="mb-3">Environment • Hackathon</Badge>
-          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">About EcoSpark</h1>
-          <p className="mt-2 text-muted-foreground">A gamified platform that turns environmental learning into measurable action.</p>
+          <Badge variant="secondary" className="mb-3">
+            Environment • Hackathon
+          </Badge>
+          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
+            About EcoSpark
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            A gamified platform that turns environmental learning into
+            measurable action.
+          </p>
         </div>
 
         <div className="mt-8 grid gap-6 sm:grid-cols-2">
           <Card className="border-primary/20">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2"><Leaf className="h-5 w-5" /> Mission</CardTitle>
-              <CardDescription>Build lifelong sustainable habits through local action.</CardDescription>
+              <CardTitle className="flex items-center gap-2">
+                <Leaf className="h-5 w-5" /> Mission
+              </CardTitle>
+              <CardDescription>
+                Build lifelong sustainable habits through local action.
+              </CardDescription>
             </CardHeader>
-            <CardContent className="text-sm text-muted-foreground">Aligned with NEP 2020 and India’s SDGs, designed with teachers and NGOs.</CardContent>
+            <CardContent className="text-sm text-muted-foreground">
+              Aligned with NEP 2020 and India’s SDGs, designed with teachers and
+              NGOs.
+            </CardContent>
           </Card>
           <Card className="border-primary/20">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2"><Users className="h-5 w-5" /> Community</CardTitle>
-              <CardDescription>Students, teachers, NGOs, and departments.</CardDescription>
+              <CardTitle className="flex items-center gap-2">
+                <Users className="h-5 w-5" /> Community
+              </CardTitle>
+              <CardDescription>
+                Students, teachers, NGOs, and departments.
+              </CardDescription>
             </CardHeader>
-            <CardContent className="text-sm text-muted-foreground">Run eco‑clubs, leaderboards, and local drives with simple tools.</CardContent>
+            <CardContent className="text-sm text-muted-foreground">
+              Run eco‑clubs, leaderboards, and local drives with simple tools.
+            </CardContent>
           </Card>
           <Card className="border-primary/20">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2"><Target className="h-5 w-5" /> Focus</CardTitle>
+              <CardTitle className="flex items-center gap-2">
+                <Target className="h-5 w-5" /> Focus
+              </CardTitle>
               <CardDescription>Waste, Water, Energy</CardDescription>
             </CardHeader>
-            <CardContent className="text-sm text-muted-foreground">Short modules, micro‑challenges, and impact tracking.</CardContent>
+            <CardContent className="text-sm text-muted-foreground">
+              Short modules, micro‑challenges, and impact tracking.
+            </CardContent>
           </Card>
           <Card className="border-primary/20">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2"><Rocket className="h-5 w-5" /> Built for Hackathons</CardTitle>
+              <CardTitle className="flex items-center gap-2">
+                <Rocket className="h-5 w-5" /> Built for Hackathons
+              </CardTitle>
               <CardDescription>Clear outcomes and fast demos</CardDescription>
             </CardHeader>
-            <CardContent className="text-sm text-muted-foreground">Beautiful UI, rapid onboarding, and sample data to showcase impact.</CardContent>
+            <CardContent className="text-sm text-muted-foreground">
+              Beautiful UI, rapid onboarding, and sample data to showcase
+              impact.
+            </CardContent>
           </Card>
         </div>
       </div>

--- a/client/pages/Account.tsx
+++ b/client/pages/Account.tsx
@@ -41,7 +41,6 @@ export default function Account() {
             {!profile ? (
               <div className="flex flex-wrap items-center gap-3">
                 <GoogleLogin mode="signin" />
-                <GoogleLogin mode="signup" />
               </div>
             ) : (
               <div className="flex items-center gap-4">

--- a/client/pages/ChallengeDetail.tsx
+++ b/client/pages/ChallengeDetail.tsx
@@ -54,18 +54,34 @@ export default function ChallengeDetail() {
   }
 
   return (
-    <section className="container py-10">
-      <div className="mx-auto max-w-3xl">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Icon name={challenge.icon} /> {challenge.title}
-            </CardTitle>
-            <CardDescription>{challenge.description}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              <div>
+    <section className="relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(60%_60%_at_10%_10%,hsl(var(--accent))_0%,transparent_50%),radial-gradient(60%_60%_at_90%_10%,hsl(var(--accent))_0%,transparent_50%)]" />
+      <div className="container py-10">
+        <div className="mx-auto max-w-3xl">
+          <Card className="border-primary/20 shadow-sm">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Icon name={challenge.icon} /> {challenge.title}
+              </CardTitle>
+              <CardDescription>{challenge.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 sm:grid-cols-3">
+                <Link to={`/challenges/${challenge.slug}/learn`} className="group rounded-lg border p-4 transition-colors hover:border-primary/40">
+                  <div className="text-sm font-semibold">Learn</div>
+                  <p className="mt-1 text-xs text-muted-foreground">Concepts and why it matters</p>
+                </Link>
+                <Link to={`/challenges/${challenge.slug}/act`} className="group rounded-lg border p-4 transition-colors hover:border-primary/40">
+                  <div className="text-sm font-semibold">Act</div>
+                  <p className="mt-1 text-xs text-muted-foreground">Steps to complete and log</p>
+                </Link>
+                <Link to={`/challenges/${challenge.slug}/rewards`} className="group rounded-lg border p-4 transition-colors hover:border-primary/40">
+                  <div className="text-sm font-semibold">Rewards</div>
+                  <p className="mt-1 text-xs text-muted-foreground">Points and badges</p>
+                </Link>
+              </div>
+
+              <div className="mt-6">
                 <p className="text-sm font-semibold">Getting started</p>
                 <ul className="mt-2 list-disc pl-5 text-sm text-muted-foreground">
                   {challenge.steps.map((s, i) => (
@@ -73,15 +89,16 @@ export default function ChallengeDetail() {
                   ))}
                 </ul>
               </div>
-              <div className="flex gap-2">
+
+              <div className="mt-4 flex gap-2">
                 <Button>Start challenge</Button>
                 <Button asChild variant="secondary">
                   <Link to="/challenges">Browse more</Link>
                 </Button>
               </div>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </section>
   );

--- a/client/pages/ChallengeDetail.tsx
+++ b/client/pages/ChallengeDetail.tsx
@@ -67,17 +67,32 @@ export default function ChallengeDetail() {
             </CardHeader>
             <CardContent>
               <div className="grid gap-4 sm:grid-cols-3">
-                <Link to={`/challenges/${challenge.slug}/learn`} className="group rounded-lg border p-4 transition-colors hover:border-primary/40">
+                <Link
+                  to={`/challenges/${challenge.slug}/learn`}
+                  className="group rounded-lg border p-4 transition-colors hover:border-primary/40"
+                >
                   <div className="text-sm font-semibold">Learn</div>
-                  <p className="mt-1 text-xs text-muted-foreground">Concepts and why it matters</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Concepts and why it matters
+                  </p>
                 </Link>
-                <Link to={`/challenges/${challenge.slug}/act`} className="group rounded-lg border p-4 transition-colors hover:border-primary/40">
+                <Link
+                  to={`/challenges/${challenge.slug}/act`}
+                  className="group rounded-lg border p-4 transition-colors hover:border-primary/40"
+                >
                   <div className="text-sm font-semibold">Act</div>
-                  <p className="mt-1 text-xs text-muted-foreground">Steps to complete and log</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Steps to complete and log
+                  </p>
                 </Link>
-                <Link to={`/challenges/${challenge.slug}/rewards`} className="group rounded-lg border p-4 transition-colors hover:border-primary/40">
+                <Link
+                  to={`/challenges/${challenge.slug}/rewards`}
+                  className="group rounded-lg border p-4 transition-colors hover:border-primary/40"
+                >
                   <div className="text-sm font-semibold">Rewards</div>
-                  <p className="mt-1 text-xs text-muted-foreground">Points and badges</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Points and badges
+                  </p>
                 </Link>
               </div>
 

--- a/client/pages/ChallengeDetail.tsx
+++ b/client/pages/ChallengeDetail.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+import { useParams, Link } from "react-router-dom";
+import { CHALLENGES, Challenge } from "./challenges-data";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Leaf, Recycle, Droplets, Bike, SunMedium } from "lucide-react";
+
+function Icon({ name }: { name: Challenge["icon"] }) {
+  const C = name === "recycle" ? Recycle : name === "droplets" ? Droplets : name === "bike" ? Bike : name === "sun" ? SunMedium : Leaf;
+  return <C className="h-5 w-5 text-primary" />;
+}
+
+export default function ChallengeDetail() {
+  const { slug } = useParams<{ slug: string }>();
+
+  const challenge = useMemo(() => CHALLENGES.find((c) => c.slug === slug), [slug]);
+
+  if (!challenge) {
+    return (
+      <section className="container py-10">
+        <Card>
+          <CardHeader>
+            <CardTitle>Challenge not found</CardTitle>
+            <CardDescription>The challenge you tried to open does not exist.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link to="/challenges">Back to challenges</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="container py-10">
+      <div className="mx-auto max-w-3xl">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Icon name={challenge.icon} /> {challenge.title}
+            </CardTitle>
+            <CardDescription>{challenge.description}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <div>
+                <p className="text-sm font-semibold">Getting started</p>
+                <ul className="mt-2 list-disc pl-5 text-sm text-muted-foreground">
+                  {challenge.steps.map((s, i) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="flex gap-2">
+                <Button>Start challenge</Button>
+                <Button asChild variant="secondary">
+                  <Link to="/challenges">Browse more</Link>
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/client/pages/ChallengeDetail.tsx
+++ b/client/pages/ChallengeDetail.tsx
@@ -1,19 +1,37 @@
 import { useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { CHALLENGES, Challenge } from "./challenges-data";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Leaf, Recycle, Droplets, Bike, SunMedium } from "lucide-react";
 
 function Icon({ name }: { name: Challenge["icon"] }) {
-  const C = name === "recycle" ? Recycle : name === "droplets" ? Droplets : name === "bike" ? Bike : name === "sun" ? SunMedium : Leaf;
+  const C =
+    name === "recycle"
+      ? Recycle
+      : name === "droplets"
+        ? Droplets
+        : name === "bike"
+          ? Bike
+          : name === "sun"
+            ? SunMedium
+            : Leaf;
   return <C className="h-5 w-5 text-primary" />;
 }
 
 export default function ChallengeDetail() {
   const { slug } = useParams<{ slug: string }>();
 
-  const challenge = useMemo(() => CHALLENGES.find((c) => c.slug === slug), [slug]);
+  const challenge = useMemo(
+    () => CHALLENGES.find((c) => c.slug === slug),
+    [slug],
+  );
 
   if (!challenge) {
     return (
@@ -21,7 +39,9 @@ export default function ChallengeDetail() {
         <Card>
           <CardHeader>
             <CardTitle>Challenge not found</CardTitle>
-            <CardDescription>The challenge you tried to open does not exist.</CardDescription>
+            <CardDescription>
+              The challenge you tried to open does not exist.
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <Button asChild>

--- a/client/pages/ChallengeSubPage.tsx
+++ b/client/pages/ChallengeSubPage.tsx
@@ -1,7 +1,13 @@
 import { Link, useParams } from "react-router-dom";
 import { CHALLENGES } from "./challenges-data";
 import { SUB_PAGES } from "./challenge-subpages";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
 export default function ChallengeSubPage() {
@@ -31,7 +37,9 @@ export default function ChallengeSubPage() {
     <section className="container py-10">
       <div className="mx-auto max-w-3xl space-y-6">
         <div className="rounded-xl border bg-gradient-to-r from-accent to-transparent p-6">
-          <h1 className="text-2xl font-extrabold tracking-tight">{challenge.title} • {subPage.title}</h1>
+          <h1 className="text-2xl font-extrabold tracking-tight">
+            {challenge.title} • {subPage.title}
+          </h1>
           <p className="mt-1 text-muted-foreground">{subPage.description}</p>
         </div>
 
@@ -43,7 +51,11 @@ export default function ChallengeSubPage() {
           <CardContent>
             {subPage.slug === "learn" && (
               <div className="prose prose-sm max-w-none dark:prose-invert">
-                <p>This section explains the background and importance of {challenge.title.toLowerCase()} with India-first context and examples.</p>
+                <p>
+                  This section explains the background and importance of{" "}
+                  {challenge.title.toLowerCase()} with India-first context and
+                  examples.
+                </p>
                 <ul>
                   {challenge.steps.map((s, i) => (
                     <li key={i}>{s}</li>
@@ -56,7 +68,9 @@ export default function ChallengeSubPage() {
                 <p>Follow these steps and log your progress to earn points:</p>
                 <ol className="list-decimal pl-4">
                   {challenge.steps.map((s, i) => (
-                    <li key={i} className="mb-1">{s}</li>
+                    <li key={i} className="mb-1">
+                      {s}
+                    </li>
                   ))}
                 </ol>
                 <Button className="mt-2">Log progress</Button>
@@ -76,8 +90,12 @@ export default function ChallengeSubPage() {
         </Card>
 
         <div className="flex gap-2">
-          <Button asChild variant="secondary"><Link to={`/challenges/${slug}`}>Back to {challenge.title}</Link></Button>
-          <Button asChild><Link to="/challenges">All challenges</Link></Button>
+          <Button asChild variant="secondary">
+            <Link to={`/challenges/${slug}`}>Back to {challenge.title}</Link>
+          </Button>
+          <Button asChild>
+            <Link to="/challenges">All challenges</Link>
+          </Button>
         </div>
       </div>
     </section>

--- a/client/pages/ChallengeSubPage.tsx
+++ b/client/pages/ChallengeSubPage.tsx
@@ -1,0 +1,85 @@
+import { Link, useParams } from "react-router-dom";
+import { CHALLENGES } from "./challenges-data";
+import { SUB_PAGES } from "./challenge-subpages";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function ChallengeSubPage() {
+  const { slug, sub } = useParams<{ slug: string; sub: string }>();
+  const challenge = CHALLENGES.find((c) => c.slug === slug);
+  const subPage = SUB_PAGES.find((s) => s.slug === sub);
+
+  if (!challenge || !subPage) {
+    return (
+      <section className="container py-10">
+        <Card>
+          <CardHeader>
+            <CardTitle>Page not found</CardTitle>
+            <CardDescription>We couldn’t find that section.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link to={`/challenges/${slug}`}>Back to challenge</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="container py-10">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="rounded-xl border bg-gradient-to-r from-accent to-transparent p-6">
+          <h1 className="text-2xl font-extrabold tracking-tight">{challenge.title} • {subPage.title}</h1>
+          <p className="mt-1 text-muted-foreground">{subPage.description}</p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>About</CardTitle>
+            <CardDescription>{challenge.description}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {subPage.slug === "learn" && (
+              <div className="prose prose-sm max-w-none dark:prose-invert">
+                <p>This section explains the background and importance of {challenge.title.toLowerCase()} with India-first context and examples.</p>
+                <ul>
+                  {challenge.steps.map((s, i) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {subPage.slug === "act" && (
+              <div className="space-y-3 text-sm text-muted-foreground">
+                <p>Follow these steps and log your progress to earn points:</p>
+                <ol className="list-decimal pl-4">
+                  {challenge.steps.map((s, i) => (
+                    <li key={i} className="mb-1">{s}</li>
+                  ))}
+                </ol>
+                <Button className="mt-2">Log progress</Button>
+              </div>
+            )}
+            {subPage.slug === "rewards" && (
+              <div className="text-sm text-muted-foreground">
+                <p>Complete tasks to unlock badges and bonus points.</p>
+                <ul className="mt-2 list-disc pl-5">
+                  <li>+10 pts for basic completion</li>
+                  <li>+20 pts for verified evidence</li>
+                  <li>Badge after 4 consecutive weeks</li>
+                </ul>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="flex gap-2">
+          <Button asChild variant="secondary"><Link to={`/challenges/${slug}`}>Back to {challenge.title}</Link></Button>
+          <Button asChild><Link to="/challenges">All challenges</Link></Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/pages/Challenges.tsx
+++ b/client/pages/Challenges.tsx
@@ -1,6 +1,15 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Leaf, Recycle, Droplets, Bike, SunMedium, BookOpen, ListChecks, Medal } from "lucide-react";
+import {
+  Leaf,
+  Recycle,
+  Droplets,
+  Bike,
+  SunMedium,
+  BookOpen,
+  ListChecks,
+  Medal,
+} from "lucide-react";
 import { Link } from "react-router-dom";
 import { CHALLENGES } from "./challenges-data";
 
@@ -50,17 +59,28 @@ export default function Challenges() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-3">
-                  <p className="text-sm text-muted-foreground">{c.description}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {c.description}
+                  </p>
                   <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                    <Link to={`/challenges/${c.slug}/learn`} className="inline-flex items-center gap-1 hover:text-foreground">
+                    <Link
+                      to={`/challenges/${c.slug}/learn`}
+                      className="inline-flex items-center gap-1 hover:text-foreground"
+                    >
                       <BookOpen className="h-3.5 w-3.5" /> Learn
                     </Link>
                     <span>•</span>
-                    <Link to={`/challenges/${c.slug}/act`} className="inline-flex items-center gap-1 hover:text-foreground">
+                    <Link
+                      to={`/challenges/${c.slug}/act`}
+                      className="inline-flex items-center gap-1 hover:text-foreground"
+                    >
                       <ListChecks className="h-3.5 w-3.5" /> Act
                     </Link>
                     <span>•</span>
-                    <Link to={`/challenges/${c.slug}/rewards`} className="inline-flex items-center gap-1 hover:text-foreground">
+                    <Link
+                      to={`/challenges/${c.slug}/rewards`}
+                      className="inline-flex items-center gap-1 hover:text-foreground"
+                    >
                       <Medal className="h-3.5 w-3.5" /> Rewards
                     </Link>
                   </div>

--- a/client/pages/Challenges.tsx
+++ b/client/pages/Challenges.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Leaf, Recycle, Droplets, Bike, SunMedium } from "lucide-react";
+import { Leaf, Recycle, Droplets, Bike, SunMedium, BookOpen, ListChecks, Medal } from "lucide-react";
 import { Link } from "react-router-dom";
 import { CHALLENGES } from "./challenges-data";
 

--- a/client/pages/Challenges.tsx
+++ b/client/pages/Challenges.tsx
@@ -49,8 +49,21 @@ export default function Challenges() {
                     <Icon name={c.icon} /> {c.title}
                   </CardTitle>
                 </CardHeader>
-                <CardContent className="text-sm text-muted-foreground">
-                  {c.description}
+                <CardContent className="space-y-3">
+                  <p className="text-sm text-muted-foreground">{c.description}</p>
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                    <Link to={`/challenges/${c.slug}/learn`} className="inline-flex items-center gap-1 hover:text-foreground">
+                      <BookOpen className="h-3.5 w-3.5" /> Learn
+                    </Link>
+                    <span>•</span>
+                    <Link to={`/challenges/${c.slug}/act`} className="inline-flex items-center gap-1 hover:text-foreground">
+                      <ListChecks className="h-3.5 w-3.5" /> Act
+                    </Link>
+                    <span>•</span>
+                    <Link to={`/challenges/${c.slug}/rewards`} className="inline-flex items-center gap-1 hover:text-foreground">
+                      <Medal className="h-3.5 w-3.5" /> Rewards
+                    </Link>
+                  </div>
                 </CardContent>
               </Card>
             </Link>

--- a/client/pages/Challenges.tsx
+++ b/client/pages/Challenges.tsx
@@ -4,8 +4,21 @@ import { Leaf, Recycle, Droplets, Bike, SunMedium } from "lucide-react";
 import { Link } from "react-router-dom";
 import { CHALLENGES } from "./challenges-data";
 
-function Icon({ name }: { name: "recycle" | "droplets" | "bike" | "sun" | "leaf" }) {
-  const C = name === "recycle" ? Recycle : name === "droplets" ? Droplets : name === "bike" ? Bike : name === "sun" ? SunMedium : Leaf;
+function Icon({
+  name,
+}: {
+  name: "recycle" | "droplets" | "bike" | "sun" | "leaf";
+}) {
+  const C =
+    name === "recycle"
+      ? Recycle
+      : name === "droplets"
+        ? Droplets
+        : name === "bike"
+          ? Bike
+          : name === "sun"
+            ? SunMedium
+            : Leaf;
   return <C className="h-5 w-5 text-primary" />;
 }
 
@@ -13,13 +26,15 @@ export default function Challenges() {
   return (
     <section className="container py-10">
       <div className="mx-auto max-w-3xl text-center">
-        <Badge variant="secondary" className="mb-3">Beta</Badge>
+        <Badge variant="secondary" className="mb-3">
+          Beta
+        </Badge>
         <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
           Daily and Weekly Eco Challenges
         </h1>
         <p className="mt-2 text-muted-foreground">
-          Explore curated, India-first tasks you can do at school, college, or home. Full
-          challenge catalog coming soon.
+          Explore curated, India-first tasks you can do at school, college, or
+          home. Full challenge catalog coming soon.
         </p>
       </div>
 
@@ -41,7 +56,8 @@ export default function Challenges() {
       </div>
 
       <p className="mt-8 text-center text-sm text-muted-foreground">
-        Want a custom challenge for your school or NGO? Reach out and we’ll add it.
+        Want a custom challenge for your school or NGO? Reach out and we’ll add
+        it.
       </p>
     </section>
   );

--- a/client/pages/Challenges.tsx
+++ b/client/pages/Challenges.tsx
@@ -24,41 +24,44 @@ function Icon({
 
 export default function Challenges() {
   return (
-    <section className="container py-10">
-      <div className="mx-auto max-w-3xl text-center">
-        <Badge variant="secondary" className="mb-3">
-          Beta
-        </Badge>
-        <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
-          Daily and Weekly Eco Challenges
-        </h1>
-        <p className="mt-2 text-muted-foreground">
-          Explore curated, India-first tasks you can do at school, college, or
-          home. Full challenge catalog coming soon.
+    <section className="relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(60%_60%_at_10%_10%,hsl(var(--accent))_0%,transparent_50%),radial-gradient(60%_60%_at_90%_10%,hsl(var(--accent))_0%,transparent_50%)]" />
+      <div className="container py-10">
+        <div className="mx-auto max-w-3xl text-center">
+          <Badge variant="secondary" className="mb-3">
+            Beta
+          </Badge>
+          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
+            Daily and Weekly Eco Challenges
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            Explore curated, India-first tasks you can do at school, college, or
+            home. Full challenge catalog coming soon.
+          </p>
+        </div>
+
+        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {CHALLENGES.map((c) => (
+            <Link key={c.slug} to={`/challenges/${c.slug}`} className="group">
+              <Card className="transition-all hover:-translate-y-0.5 hover:shadow-sm group-hover:border-primary/40">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Icon name={c.icon} /> {c.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="text-sm text-muted-foreground">
+                  {c.description}
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+
+        <p className="mt-8 text-center text-sm text-muted-foreground">
+          Want a custom challenge for your school or NGO? Reach out and we’ll add
+          it.
         </p>
       </div>
-
-      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {CHALLENGES.map((c) => (
-          <Link key={c.slug} to={`/challenges/${c.slug}`} className="group">
-            <Card className="transition-colors group-hover:border-primary/40">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Icon name={c.icon} /> {c.title}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
-                {c.description}
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
-      </div>
-
-      <p className="mt-8 text-center text-sm text-muted-foreground">
-        Want a custom challenge for your school or NGO? Reach out and we’ll add
-        it.
-      </p>
     </section>
   );
 }

--- a/client/pages/Challenges.tsx
+++ b/client/pages/Challenges.tsx
@@ -58,8 +58,8 @@ export default function Challenges() {
         </div>
 
         <p className="mt-8 text-center text-sm text-muted-foreground">
-          Want a custom challenge for your school or NGO? Reach out and we’ll add
-          it.
+          Want a custom challenge for your school or NGO? Reach out and we’ll
+          add it.
         </p>
       </div>
     </section>

--- a/client/pages/Challenges.tsx
+++ b/client/pages/Challenges.tsx
@@ -1,6 +1,13 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Leaf, Recycle, Droplets, Bike, SunMedium } from "lucide-react";
+import { Link } from "react-router-dom";
+import { CHALLENGES } from "./challenges-data";
+
+function Icon({ name }: { name: "recycle" | "droplets" | "bike" | "sun" | "leaf" }) {
+  const C = name === "recycle" ? Recycle : name === "droplets" ? Droplets : name === "bike" ? Bike : name === "sun" ? SunMedium : Leaf;
+  return <C className="h-5 w-5 text-primary" />;
+}
 
 export default function Challenges() {
   return (
@@ -17,56 +24,20 @@ export default function Challenges() {
       </div>
 
       <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Recycle className="h-5 w-5 text-primary" /> Waste Segregation
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-muted-foreground">
-            Start a 3-bin system for dry, wet, and reject waste. Earn points by keeping logs and photos.
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Droplets className="h-5 w-5 text-primary" /> Save Water
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-muted-foreground">
-            Conduct a tap-leak audit on campus. Submit findings and fixes for bonus points.
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Bike className="h-5 w-5 text-primary" /> Walk/Cycle to School
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-muted-foreground">
-            Replace one car/scooter trip per week. Track your CO₂ saved.
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <SunMedium className="h-5 w-5 text-primary" /> Energy Audit
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-muted-foreground">
-            Switch off idle fans/lights. Map high-usage areas and propose improvements.
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Leaf className="h-5 w-5 text-primary" /> Tree Plantation
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-muted-foreground">
-            Participate in local drives. Care for saplings for 6 months to earn a badge.
-          </CardContent>
-        </Card>
+        {CHALLENGES.map((c) => (
+          <Link key={c.slug} to={`/challenges/${c.slug}`} className="group">
+            <Card className="transition-colors group-hover:border-primary/40">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Icon name={c.icon} /> {c.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">
+                {c.description}
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
       </div>
 
       <p className="mt-8 text-center text-sm text-muted-foreground">

--- a/client/pages/Impact.tsx
+++ b/client/pages/Impact.tsx
@@ -1,0 +1,91 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { Badge } from "@/components/ui/badge";
+import { Leaf, Droplets, SunMedium } from "lucide-react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  CartesianGrid,
+} from "recharts";
+
+const data = [
+  { month: "Jan", co2: 12, water: 80, energy: 50 },
+  { month: "Feb", co2: 18, water: 95, energy: 60 },
+  { month: "Mar", co2: 26, water: 120, energy: 74 },
+  { month: "Apr", co2: 33, water: 140, energy: 86 },
+  { month: "May", co2: 45, water: 160, energy: 103 },
+  { month: "Jun", co2: 58, water: 190, energy: 122 },
+];
+
+const config = {
+  co2: {
+    label: "CO₂ saved (kg)",
+    icon: Leaf,
+    theme: { light: "hsl(152 61% 45%)", dark: "hsl(152 61% 45%)" },
+  },
+  water: {
+    label: "Water saved (L)",
+    icon: Droplets,
+    theme: { light: "hsl(199 89% 48%)", dark: "hsl(199 89% 48%)" },
+  },
+  energy: {
+    label: "Energy saved (kWh)",
+    icon: SunMedium,
+    theme: { light: "hsl(42 95% 56%)", dark: "hsl(42 95% 56%)" },
+  },
+};
+
+export default function Impact() {
+  return (
+    <section className="relative overflow-hidden">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(60%_60%_at_10%_10%,hsl(var(--accent))_0%,transparent_50%),radial-gradient(60%_60%_at_90%_10%,hsl(var(--accent))_0%,transparent_50%)]" />
+      <div className="container py-10">
+        <div className="mx-auto max-w-4xl">
+          <div className="text-center">
+            <Badge variant="secondary" className="mb-3">Hackathon Ready</Badge>
+            <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">Real-world Impact</h1>
+            <p className="mt-2 text-muted-foreground">Track environmental outcomes from student actions across CO₂, water, and energy.</p>
+          </div>
+
+          <Card className="mt-8 border-primary/20 shadow-sm">
+            <CardHeader>
+              <CardTitle>School-wide progress</CardTitle>
+              <CardDescription>Aggregated metrics (sample data)</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ChartContainer config={config} className="w-full">
+                <AreaChart data={data} margin={{ left: 12, right: 12 }}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="month" tickLine={false} axisLine={false} />
+                  <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+                  <Area type="monotone" dataKey="co2" stroke="var(--color-co2)" fill="var(--color-co2)" fillOpacity={0.2} />
+                  <Area type="monotone" dataKey="water" stroke="var(--color-water)" fill="var(--color-water)" fillOpacity={0.15} />
+                  <Area type="monotone" dataKey="energy" stroke="var(--color-energy)" fill="var(--color-energy)" fillOpacity={0.15} />
+                </AreaChart>
+              </ChartContainer>
+              <ChartLegend content={<ChartLegendContent />} />
+            </CardContent>
+          </Card>
+
+          <div className="mt-8 grid gap-6 sm:grid-cols-3">
+            <Stat label="CO₂ saved" value="58 kg" sub="last 6 months" />
+            <Stat label="Water saved" value="190 L" sub="last 6 months" />
+            <Stat label="Energy saved" value="122 kWh" sub="last 6 months" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Stat({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <Card className="border-primary/20">
+      <CardHeader>
+        <CardTitle className="text-xl">{value}</CardTitle>
+        <CardDescription>{label} • {sub}</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/client/pages/Impact.tsx
+++ b/client/pages/Impact.tsx
@@ -1,13 +1,20 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 import { Badge } from "@/components/ui/badge";
 import { Leaf, Droplets, SunMedium } from "lucide-react";
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  CartesianGrid,
-} from "recharts";
+import { AreaChart, Area, XAxis, CartesianGrid } from "recharts";
 
 const data = [
   { month: "Jan", co2: 12, water: 80, energy: 50 },
@@ -43,25 +50,55 @@ export default function Impact() {
       <div className="container py-10">
         <div className="mx-auto max-w-4xl">
           <div className="text-center">
-            <Badge variant="secondary" className="mb-3">Hackathon Ready</Badge>
-            <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">Real-world Impact</h1>
-            <p className="mt-2 text-muted-foreground">Track environmental outcomes from student actions across CO₂, water, and energy.</p>
+            <Badge variant="secondary" className="mb-3">
+              Hackathon Ready
+            </Badge>
+            <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
+              Real-world Impact
+            </h1>
+            <p className="mt-2 text-muted-foreground">
+              Track environmental outcomes from student actions across CO₂,
+              water, and energy.
+            </p>
           </div>
 
           <Card className="mt-8 border-primary/20 shadow-sm">
             <CardHeader>
               <CardTitle>School-wide progress</CardTitle>
-              <CardDescription>Aggregated metrics (sample data)</CardDescription>
+              <CardDescription>
+                Aggregated metrics (sample data)
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <ChartContainer config={config} className="w-full">
                 <AreaChart data={data} margin={{ left: 12, right: 12 }}>
                   <CartesianGrid vertical={false} />
                   <XAxis dataKey="month" tickLine={false} axisLine={false} />
-                  <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
-                  <Area type="monotone" dataKey="co2" stroke="var(--color-co2)" fill="var(--color-co2)" fillOpacity={0.2} />
-                  <Area type="monotone" dataKey="water" stroke="var(--color-water)" fill="var(--color-water)" fillOpacity={0.15} />
-                  <Area type="monotone" dataKey="energy" stroke="var(--color-energy)" fill="var(--color-energy)" fillOpacity={0.15} />
+                  <ChartTooltip
+                    cursor={false}
+                    content={<ChartTooltipContent />}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="co2"
+                    stroke="var(--color-co2)"
+                    fill="var(--color-co2)"
+                    fillOpacity={0.2}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="water"
+                    stroke="var(--color-water)"
+                    fill="var(--color-water)"
+                    fillOpacity={0.15}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="energy"
+                    stroke="var(--color-energy)"
+                    fill="var(--color-energy)"
+                    fillOpacity={0.15}
+                  />
                 </AreaChart>
               </ChartContainer>
               <ChartLegend content={<ChartLegendContent />} />
@@ -79,12 +116,22 @@ export default function Impact() {
   );
 }
 
-function Stat({ label, value, sub }: { label: string; value: string; sub: string }) {
+function Stat({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+}) {
   return (
     <Card className="border-primary/20">
       <CardHeader>
         <CardTitle className="text-xl">{value}</CardTitle>
-        <CardDescription>{label} • {sub}</CardDescription>
+        <CardDescription>
+          {label} • {sub}
+        </CardDescription>
       </CardHeader>
     </Card>
   );

--- a/client/pages/challenge-subpages.ts
+++ b/client/pages/challenge-subpages.ts
@@ -1,5 +1,3 @@
-import { BookOpen, ListChecks, Medal } from "lucide-react";
-
 export type SubPage = {
   slug: "learn" | "act" | "rewards";
   title: string;
@@ -27,8 +25,3 @@ export const SUB_PAGES: SubPage[] = [
     icon: "medal",
   },
 ];
-
-export function SubIcon({ name, className }: { name: SubPage["icon"]; className?: string }) {
-  const C = name === "book" ? BookOpen : name === "check" ? ListChecks : Medal;
-  return <C className={className} />;
-}

--- a/client/pages/challenge-subpages.ts
+++ b/client/pages/challenge-subpages.ts
@@ -1,0 +1,34 @@
+import { BookOpen, ListChecks, Medal } from "lucide-react";
+
+export type SubPage = {
+  slug: "learn" | "act" | "rewards";
+  title: string;
+  description: string;
+  icon: "book" | "check" | "medal";
+};
+
+export const SUB_PAGES: SubPage[] = [
+  {
+    slug: "learn",
+    title: "Learn",
+    description: "Concepts, why it matters, local examples.",
+    icon: "book",
+  },
+  {
+    slug: "act",
+    title: "Act",
+    description: "Step-by-step tasks to complete and log.",
+    icon: "check",
+  },
+  {
+    slug: "rewards",
+    title: "Rewards",
+    description: "Points, badges, and how to level up.",
+    icon: "medal",
+  },
+];
+
+export function SubIcon({ name, className }: { name: SubPage["icon"]; className?: string }) {
+  const C = name === "book" ? BookOpen : name === "check" ? ListChecks : Medal;
+  return <C className={className} />;
+}

--- a/client/pages/challenges-data.ts
+++ b/client/pages/challenges-data.ts
@@ -1,0 +1,85 @@
+import { Bike, Droplets, Leaf, Recycle, SunMedium } from "lucide-react";
+
+export type Challenge = {
+  slug: string;
+  title: string;
+  description: string;
+  icon: "recycle" | "droplets" | "bike" | "sun" | "leaf";
+  steps: string[];
+};
+
+export const CHALLENGES: Challenge[] = [
+  {
+    slug: "waste-segregation",
+    title: "Waste Segregation",
+    description:
+      "Start a 3-bin system for dry, wet, and reject waste. Earn points by keeping logs and photos.",
+    icon: "recycle",
+    steps: [
+      "Set up three bins labeled Dry, Wet, Reject",
+      "Educate classmates/household on what goes where",
+      "Track your segregation for 7 days and upload photos",
+    ],
+  },
+  {
+    slug: "save-water",
+    title: "Save Water",
+    description:
+      "Conduct a tap-leak audit on campus. Submit findings and fixes for bonus points.",
+    icon: "droplets",
+    steps: [
+      "Audit taps and list leaks with locations",
+      "Report to facility/parent/warden and suggest fixes",
+      "Verify fixes and estimate water saved",
+    ],
+  },
+  {
+    slug: "walk-cycle-to-school",
+    title: "Walk/Cycle to School",
+    description: "Replace one car/scooter trip per week. Track your CO₂ saved.",
+    icon: "bike",
+    steps: [
+      "Plan a safe walking/cycling route",
+      "Invite 1–2 friends to join",
+      "Log distance and days completed this week",
+    ],
+  },
+  {
+    slug: "energy-audit",
+    title: "Energy Audit",
+    description:
+      "Switch off idle fans/lights. Map high-usage areas and propose improvements.",
+    icon: "sun",
+    steps: [
+      "Identify top 3 rooms with most devices left ON",
+      "Create switch-off checklist and assign monitors",
+      "Share before/after photos and estimate savings",
+    ],
+  },
+  {
+    slug: "tree-plantation",
+    title: "Tree Plantation",
+    description:
+      "Participate in local drives. Care for saplings for 6 months to earn a badge.",
+    icon: "leaf",
+    steps: [
+      "Plant native saplings with local NGO/club",
+      "Water and mulch regularly for 8 weeks",
+      "Share growth updates monthly for 6 months",
+    ],
+  },
+];
+
+export function ChallengeIcon({ name, className }: { name: Challenge["icon"]; className?: string }) {
+  const C =
+    name === "recycle"
+      ? Recycle
+      : name === "droplets"
+        ? Droplets
+        : name === "bike"
+          ? Bike
+          : name === "sun"
+            ? SunMedium
+            : Leaf;
+  return <C className={className} />;
+}

--- a/client/pages/challenges-data.ts
+++ b/client/pages/challenges-data.ts
@@ -1,5 +1,3 @@
-import { Bike, Droplets, Leaf, Recycle, SunMedium } from "lucide-react";
-
 export type Challenge = {
   slug: string;
   title: string;
@@ -69,17 +67,3 @@ export const CHALLENGES: Challenge[] = [
     ],
   },
 ];
-
-export function ChallengeIcon({ name, className }: { name: Challenge["icon"]; className?: string }) {
-  const C =
-    name === "recycle"
-      ? Recycle
-      : name === "droplets"
-        ? Droplets
-        : name === "bike"
-          ? Bike
-          : name === "sun"
-            ? SunMedium
-            : Leaf;
-  return <C className={className} />;
-}


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses two main issues:
- Users couldn't see content properly on screen (visibility issues)
- Users wanted more detailed pages when clicking challenge items
- Users requested consolidating duplicate sign-in options into a single login method

## Code changes

### Challenge Detail Pages
- **Added new route**: `/challenges/:slug` for individual challenge detail pages
- **Created `ChallengeDetail.tsx`**: New page component displaying detailed challenge information including steps and actions
- **Created `challenges-data.ts`**: Centralized data structure for challenge information with slugs, descriptions, and step-by-step instructions
- **Updated `Challenges.tsx`**: Converted static challenge cards to clickable links that navigate to detail pages
- **Enhanced navigation**: Challenge cards now have hover effects and link to individual challenge pages

### Account Login Simplification
- **Removed duplicate login**: Eliminated the separate "signup" Google login button from the Account page
- **Streamlined authentication**: Now uses a single Google login button instead of two separate signin/signup options

### Technical Improvements
- Added proper TypeScript types for Challenge data structure
- Implemented dynamic routing with URL parameters
- Added error handling for non-existent challenge pages
- Improved component reusability with shared Icon componentTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/663cc2f58bff4e6c9b9d5d21cff95824/zenith-hub)

👀 [Preview Link](https://663cc2f58bff4e6c9b9d5d21cff95824-zenith-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>663cc2f58bff4e6c9b9d5d21cff95824</projectId>-->
<!--<branchName>zenith-hub</branchName>-->